### PR TITLE
average_ bugfix

### DIFF
--- a/jstrisfunctions.py
+++ b/jstrisfunctions.py
@@ -421,12 +421,13 @@ def average_(list_of_runs: list, my_param: str) -> [float, str]:
 
     stat_average = 0
     numgames = 0
-
     for i in list_of_runs:
         stat_average += i[my_param]
         numgames += 1
     if my_param == "seconds":
-        return str(datetime.timedelta(seconds=round(stat_average / numgames, 2)))[:-3]
+        if '.' in str(datetime.timedelta(seconds=round(stat_average / numgames, 2))):
+            return str(datetime.timedelta(seconds=round(stat_average / numgames, 2)))[:-3]
+        return str(datetime.timedelta(seconds=round(stat_average / numgames, 2)))
     return round(stat_average/len(list_of_runs), 2)
 
 


### PR DESCRIPTION
Fixed edge case where seconds in clock format not having any decimals changes the amount of trailing floating point values.